### PR TITLE
Support for multiple labels and shapes

### DIFF
--- a/src/neovis.js
+++ b/src/neovis.js
@@ -116,16 +116,33 @@ export default class NeoVis {
 	 * @returns {{}}
 	 */
 	async buildNodeVisObject(neo4jNode) {
-		let node = {};
-		let label = neo4jNode.labels[0];
-
-		let labelConfig = this._config && this._config.labels && (this._config.labels[label] || this._config.labels[NEOVIS_DEFAULT_CONFIG]);
+        let node = {};
+        let label = neo4jNode.labels[0];
+        let labelConfig = this._config && this._config.labels && this._config.labels[NEOVIS_DEFAULT_CONFIG];
+        let configuredLabels = this._config && this._config.labels;
+        console.log("config = " + this._config)
+        console.log("config.labels = " + this._config.labels)
+        if (configuredLabels !== undefined) {
+            for (var i = 0 ; i < neo4jNode.labels.length ; i++) {
+                console.log("picking labels from: " + neo4jNode.labels)
+                console.log("configured labels: " + Object.keys(configuredLabels))
+                //@TODO: prioritize labels higher in the list
+                if (configuredLabels[neo4jNode.labels[i]] !== undefined) {
+                    label = neo4jNode.labels[i];
+                    labelConfig = configuredLabels[label];
+                    break;
+                }
+            }
+        }
+        console.log("label = " + label)
+        console.log("labelConfig = " + labelConfig)
 
 		const captionKey = labelConfig && labelConfig['caption'];
 		const sizeKey = labelConfig && labelConfig['size'];
 		const sizeCypher = labelConfig && labelConfig['sizeCypher'];
 		const communityKey = labelConfig && labelConfig['community'];
-		const imageUrl = labelConfig && labelConfig['image'];
+        const imageUrl = labelConfig && labelConfig['image'];
+        const shapeName = labelConfig && labelConfig['shape'];
 		const font = labelConfig && labelConfig['font'];
 
 		const title_properties = (
@@ -216,7 +233,9 @@ export default class NeoVis {
 		// set node shape and image url if a image url is provided in config
 		if (imageUrl) {
 			node.shape = 'image';
-			node.image = imageUrl;
+            node.image = imageUrl;
+        } else if (shapeName) {
+            node.shape = shapeName;
 		} else {
 			node.shape = 'dot';
 		}
@@ -375,7 +394,7 @@ export default class NeoVis {
 							nodes: {
 								//shape: 'dot',
 								font: {
-									size: 26,
+									size: 12,
 									strokeWidth: 7
 								},
 								scaling: {


### PR DESCRIPTION
re: https://tranquildata.atlassian.net/browse/HC-137
We use multiple labels, so we needed to wedge that in. The underlying visualization library supports basic shapes, so I just plumbed that through, too. Here's a picture of the graph with record, session, subject and relationship nodes:

<img width="887" alt="Screen Shot 2021-02-03 at 5 33 04 PM" src="https://user-images.githubusercontent.com/54280521/106818150-e7a41980-6645-11eb-9a67-12f3796bc911.png">

Supporting different colors as well as line styles is totally possible, too. I'll also be putting up another PR with the html and styling stuff to use this.