### PR TITLE
Colors and basic edge styling support

### DIFF
--- a/README-tranquil.md
+++ b/README-tranquil.md
@@ -1,0 +1,12 @@
+How do I build this fusty javascript thing?
+
+First install npm
+`brew install npm`
+
+Then install the project dependencies
+`npm install`
+
+Then build the project
+`npm run build`
+
+At this point all the fiddly bits will be in the dist directory. If you're doing this to build the tqd-visualizer, then you're done (the HTML files point to dist). If you're doing this independently, then you'll need an HTML file to make this javascript available to a browser. Look at the tqd-visualizer project for an example (index.html)

--- a/src/neovis.js
+++ b/src/neovis.js
@@ -143,14 +143,19 @@ export default class NeoVis {
 		const communityKey = labelConfig && labelConfig['community'];
         const imageUrl = labelConfig && labelConfig['image'];
         const shapeName = labelConfig && labelConfig['shape'];
-		const font = labelConfig && labelConfig['font'];
+        const font = labelConfig && labelConfig['font'];
+        const color = labelConfig && labelConfig['color'];
 
 		const title_properties = (
 			labelConfig && labelConfig.title_properties
 		) || Object.keys(neo4jNode.properties);
 
 		node.id = neo4jNode.identity.toInt();
-		node.raw = neo4jNode;
+        node.raw = neo4jNode;
+        
+        if (color !== undefined) {
+            node.color = color;
+        }
 
 		// node size
 
@@ -257,7 +262,8 @@ export default class NeoVis {
 		const nodeTypeConfig = this._config && this._config.relationships &&
 			(this._config.relationships[r.type] || this._config.relationships[NEOVIS_DEFAULT_CONFIG]);
 		let weightKey = nodeTypeConfig && nodeTypeConfig.thickness,
-			captionKey = nodeTypeConfig && nodeTypeConfig.caption;
+            captionKey = nodeTypeConfig && nodeTypeConfig.caption,
+            dashes = nodeTypeConfig && nodeTypeConfig.dashes;
 
 		let edge = {};
 		edge.id = r.identity.toInt();
@@ -299,7 +305,11 @@ export default class NeoVis {
 			}
 		} else {
 			edge.label = r.type;
-		}
+        }
+        
+        if (dashes) {
+            edge.dashes = true
+        }
 		return edge;
 	}
 


### PR DESCRIPTION
re: https://tranquildata.atlassian.net/browse/HC-137
With this, we can do everything the neo4j visualizer can, as well as much more. The visualizer code can be invoked dynamically, so this can easily be used to visualize a set of canned queries (e.g. show the subject context).
Here's an example of what the graph looks like:
<img width="869" alt="Screen Shot 2021-02-04 at 9 26 43 AM" src="https://user-images.githubusercontent.com/54280521/106906923-abb39780-66cb-11eb-89bf-d9cb38da0353.png">
